### PR TITLE
Replace default status 420 with 429 Too Many Requests

### DIFF
--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -8,7 +8,7 @@
   {:service-compojure-throttle-enabled "true"
    :service-compojure-throttle-ttl    1000
    :service-compojure-throttle-tokens 3
-   :service-compojure-throttle-response-code 420})
+   :service-compojure-throttle-response-code 429})
 
 (defn enabled?
   []


### PR DESCRIPTION
Could be a minor breaking change, but seems like a more appropriate response status.

http://tools.ietf.org/html/rfc6585
