### PR TITLE
Upgraded libraries. Fixed deprecations.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
             
-  :dependencies [[org.clojure/clojure "1.5.0"]
-                 [org.clojure/core.cache "0.6.2"]
-                 [midje "1.5.1"]
-                 [clj-time "0.4.3"]
-                 [environ "0.3.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/core.cache "0.6.4"]
+                 [clj-time "0.11.0"]
+                 [environ "1.0.1"]]
 
   :lein-release {:deploy-via :clojars}
 
-  :profiles {:dev {:plugins [[lein-midje "2.0.0-SNAPSHOT"]
+  :profiles {:dev {:dependencies [[midje "1.8.2"]]
+                   :plugins [[lein-midje "2.0.0-SNAPSHOT"]
                              [lein-release "1.0.5"]]}})

--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -48,7 +48,7 @@
   (when-not (cache/has? @requests id)
     (update-cache id (record (prop :service-compojure-throttle-tokens))))
   (let [entry (cache/lookup @requests id)
-        spares (int (/ (core-time/in-msecs (core-time/interval
+        spares (int (/ (core-time/in-millis (core-time/interval
                                             (:datetime entry)
                                             (local-time/local-now)))
                        (token-period)))


### PR DESCRIPTION
Hello! I don't know what your policy is about tracking the latest versions of your dependencies, but here's an upgrade that makes using compojure-throttle easier in 2015.
